### PR TITLE
use standard gnome-shell icon spacing for indicator icon

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -40,15 +40,15 @@ class SyncthingPanelIcon {
 		);
 		this._idleIcon = new St.Icon({
 			gicon: Gio.icon_new_for_string(Me.path + '/icons/syncthing-idle.svg'),
-			icon_size: 20
+			style_class : 'system-status-icon',
 		});
 		this._pausedIcon = new St.Icon({
 			gicon: Gio.icon_new_for_string(Me.path + '/icons/syncthing-paused.svg'),
-			icon_size: 20
+			style_class : 'system-status-icon',
 		});
 		this._disconnectedIcon = new St.Icon({
 			gicon: Gio.icon_new_for_string(Me.path + '/icons/syncthing-disconnected.svg'),
-			icon_size: 20
+			style_class : 'system-status-icon',
 		});
 		this.actor = new St.Bin();
 		this.actor.set_child(this._disconnectedIcon);


### PR DESCRIPTION
by using the right style class for the indicator icon, the spacing becomes correct instead of too narrow:

![image](https://user-images.githubusercontent.com/748944/230057203-fc8c24a0-cab8-460d-9138-33d1ecd95de5.png)
