### PR TITLE
state is undefined

### DIFF
--- a/src/syncthing.js
+++ b/src/syncthing.js
@@ -729,16 +729,14 @@ export const Manager = class Manager extends Signals.EventEmitter {
 
 	_serviceState(user = false) {
 		let command = this._serviceCommand('is-enabled', user), enabled = (command == 'enabled'), disabled = (command == 'disabled');
-		if (enabled) {
-			return {
-				user: user,
-				enabled: enabled,
-				disabled: disabled
-			}
-		} else if (!user) {
-			return this._serviceState(!user);
+		if (!enabled && !user) {
+			return this._serviceState(true);
 		}
-
+		return {
+			user: user,
+			enabled: enabled,
+			disabled: disabled
+		}
 	}
 
 	_isServiceActive() {


### PR DESCRIPTION
The `if` is missing out the case, when the service is solely defined in `~/.config/systemd/user/syncthing.service` and not enabled, leading to `state is undefined`.