### PR TITLE
Aborting connections to get rid of the warning when stopping the service

### DIFF
--- a/src/syncthing.js
+++ b/src/syncthing.js
@@ -886,6 +886,7 @@ export const Manager = class Manager extends Signals.EventEmitter {
 	}
 
 	stopService() {
+		this.abortConnections();
 		this._serviceCommand('stop');
 	}
 


### PR DESCRIPTION
see title :tada: 