### PR TITLE
fix pollState unhandled rejection loop (#63)

### DIFF
--- a/src/syncthing.js
+++ b/src/syncthing.js
@@ -729,39 +729,44 @@ export class Manager extends Utils.Emitter {
       this.#pollCount % POLL_CONFIG_HOOK_COUNT,
       this.#pollCount % POLL_CONNECTION_HOOK_COUNT,
     );
-    if (
-      (await this.#extensionConfig.exists()) &&
-      (await this.#isServiceActive())
-    ) {
-      if (this.#pollCount % POLL_CONFIG_HOOK_COUNT == 0) {
-        await this.#callConfig();
-        await this.#checkPendingRequests();
-      }
-      if (this.#pollCount % POLL_CONNECTION_HOOK_COUNT == 0) {
-        await this.#isServiceEnabled();
-        await this.#callConnections();
-      }
-      this.#openConnection("GET", "/rest/system/error", (data) => {
-        let errorTime;
-        const errors = data.errors;
-        if (errors != null) {
-          for (let i = 0; i < errors.length; i++) {
-            errorTime = new Date(errors[i].when);
-            if (errorTime > this.#lastErrorTime) {
-              this.#lastErrorTime = errorTime;
-              console.error(LOG_PREFIX, Error.SERVICE, errors[i]);
-              this.emit(Signal.ERROR, {
-                type: Error.SERVICE,
-                message: errors[i].message,
-              });
+    try {
+      if (
+        (await this.#extensionConfig.exists()) &&
+        (await this.#isServiceActive())
+      ) {
+        if (this.#pollCount % POLL_CONFIG_HOOK_COUNT == 0) {
+          await this.#callConfig();
+          await this.#checkPendingRequests();
+        }
+        if (this.#pollCount % POLL_CONNECTION_HOOK_COUNT == 0) {
+          await this.#isServiceEnabled();
+          await this.#callConnections();
+        }
+        await this.#openConnection("GET", "/rest/system/error", (data) => {
+          let errorTime;
+          const errors = data.errors;
+          if (errors != null) {
+            for (let i = 0; i < errors.length; i++) {
+              errorTime = new Date(errors[i].when);
+              if (errorTime > this.#lastErrorTime) {
+                this.#lastErrorTime = errorTime;
+                console.error(LOG_PREFIX, Error.SERVICE, errors[i]);
+                this.emit(Signal.ERROR, {
+                  type: Error.SERVICE,
+                  message: errors[i].message,
+                });
+              }
             }
           }
-        }
-      });
-    } else {
-      await this.#isServiceEnabled();
+        });
+      } else {
+        await this.#isServiceEnabled();
+      }
+    } catch (error) {
+      console.error(LOG_PREFIX, "poll state error", error);
+    } finally {
+      this.#pollCount++;
     }
-    this.#pollCount++;
   }
 
   #setService(force = false) {
@@ -911,29 +916,33 @@ export class Manager extends Utils.Emitter {
 
   async #serviceCall(method, path) {
     return new Promise((resolve, reject) => {
-      try {
-        this.#openConnection(method, path, resolve);
-      } catch (error) {
-        reject(error);
-      }
+      this.#openConnection(method, path, resolve, reject);
     });
   }
 
-  async #openConnection(method, path, callback) {
-    if (await this.#extensionConfig.exists()) {
-      let msg = Soup.Message.new(method, this.#extensionConfig.URI + path);
-      // Accept self signed certificates (for now)
-      msg.connect("accept-certificate", () => {
-        return true;
-      });
-      msg.request_headers.append("X-API-Key", this.#extensionConfig.APIKey);
-      this.#openConnectionMessage(msg, callback);
+  async #openConnection(method, path, callback, errorCallback) {
+    try {
+      if (await this.#extensionConfig.exists()) {
+        let msg = Soup.Message.new(method, this.#extensionConfig.URI + path);
+        // Accept self signed certificates (for now)
+        msg.connect("accept-certificate", () => {
+          return true;
+        });
+        msg.request_headers.append("X-API-Key", this.#extensionConfig.APIKey);
+        this.#openConnectionMessage(msg, callback, errorCallback);
+      } else if (errorCallback) {
+        errorCallback(new globalThis.Error(Error.CONFIG));
+      }
+    } catch (error) {
+      if (errorCallback) errorCallback(error);
+      else console.error(LOG_PREFIX, "open connection error", error);
     }
   }
 
-  async #openConnectionMessage(msg, callback) {
-    // if ((await this.#extensionConfig.exists()) && this.#serviceActive) {
-    if (await this.#extensionConfig.exists()) {
+  async #openConnectionMessage(msg, callback, errorCallback) {
+    try {
+      // if ((await this.#extensionConfig.exists()) && this.#serviceActive) {
+      if (await this.#extensionConfig.exists()) {
       console.debug(
         LOG_PREFIX,
         "opening connection",
@@ -945,6 +954,7 @@ export class Manager extends Utils.Emitter {
         null,
         (session, result) => {
           let connected = false;
+          let errorReported = false;
           if (msg.status_code == Soup.Status.OK) {
             connected = true;
             let response;
@@ -962,19 +972,28 @@ export class Manager extends Utils.Emitter {
                 );
                 // Retry this connection attempt
                 Utils.Timer.run(CONNECTION_RETRY_DELAY, () => {
-                  this.#openConnectionMessage(msg, callback);
+                  this.#openConnectionMessage(msg, callback, errorCallback);
                 });
+                return;
+              }
+              if (errorCallback) {
+                errorCallback(error);
+                errorReported = true;
               }
             }
             try {
-              if (callback && response && response.length > 0) {
+              if (response && response.length > 0) {
                 console.debug(
                   LOG_PREFIX,
                   "callback",
                   msg.method + ":" + msg.uri.get_path(),
                   response,
                 );
-                callback(JSON.parse(response));
+                const parsed = JSON.parse(response);
+                if (callback) callback(parsed);
+              } else if (errorCallback && !errorReported) {
+                errorCallback(new globalThis.Error("empty response"));
+                errorReported = true;
               }
             } catch (error) {
               console.error(
@@ -988,6 +1007,10 @@ export class Manager extends Utils.Emitter {
                 type: Error.STREAM,
                 message: msg.method + ":" + msg.uri.get_path(),
               });
+              if (errorCallback && !errorReported) {
+                errorCallback(error);
+                errorReported = true;
+              }
             }
           } else if (!this.#httpAborting) {
             this.#httpErrorCount++;
@@ -1014,6 +1037,23 @@ export class Manager extends Utils.Emitter {
                 ":" +
                 msg.get_uri().get_path(),
             });
+            if (errorCallback) {
+              errorCallback(
+                new globalThis.Error(
+                  Error.CONNECTION +
+                    " " +
+                    msg.status_code +
+                    " " +
+                    msg.method +
+                    ":" +
+                    msg.get_uri().get_path(),
+                ),
+              );
+              errorReported = true;
+            }
+          } else if (this.#httpAborting && errorCallback) {
+            errorCallback(new globalThis.Error("aborted"));
+            errorReported = true;
           }
           if (!this.#httpAborting && connected != this.#serviceConnected) {
             this.#serviceConnected = connected;
@@ -1024,6 +1064,12 @@ export class Manager extends Utils.Emitter {
           }
         },
       );
+      } else if (errorCallback) {
+        errorCallback(new globalThis.Error(Error.CONFIG));
+      }
+    } catch (error) {
+      if (errorCallback) errorCallback(error);
+      else console.error(LOG_PREFIX, "open connection message error", error);
     }
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -111,7 +111,16 @@ export class Timer {
     this.#source = GLib.timeout_source_new(timeout);
     this.#source.set_priority(priority);
     this.#source.set_callback(() => {
-      callback();
+      try {
+        const ret = callback();
+        if (ret instanceof Promise) {
+          ret.catch((error) =>
+            console.error(LOG_PREFIX, "timer callback error", error),
+          );
+        }
+      } catch (error) {
+        console.error(LOG_PREFIX, "timer callback error", error);
+      }
       if (recurring) {
         this.#run(callback, timeout, recurring, priority);
       } else {


### PR DESCRIPTION
## Summary

Closes #63.

\`#serviceCall\` returned a Promise that was only ever resolved on \`Soup.Status.OK\`. On any other status — or whenever the daemon was unreachable — the promise hung forever, which kept the underlying \`Soup.Message\` wrappers alive long enough for the libsoup \`soup_message_queue_item_destroy\` runtime check to trip during GC, and the awaiting \`#pollState\` chain emitted an unhandled rejection every poll cycle. Combined, these caused the gnome-shell CPU/RSS climb described in the issue.

This PR plumbs an \`errorCallback\` through \`#openConnection\` / \`#openConnectionMessage\` so non-OK status, abort, JSON parse failure, missing config, and IO errors all reject \`#serviceCall\` cleanly. \`#pollState\` is wrapped in \`try/catch + finally\` so the poll counter still advances even when an await throws, and \`Utils.Timer\` catches stray async-callback rejections as a belt-and-braces guard.

Two related cleanups that surfaced while investigating this issue have been split into their own PRs to keep this one focused:

- #69 — destructure stdout from \`communicate_utf8_async\` + silence stderr (pre-existing latent bug in \`#serviceCommand\`)
- #70 — support Syncthing 1.29 \`serve --paths\` (separate breakage causing \`unexpected argument paths\` log noise)

## Test plan

- [ ] Install the patched extension and reload the GNOME shell session.
- [ ] With Syncthing running, leave the session up for several hours and confirm \`gnome-shell\` CPU/RSS stays flat.
- [ ] Stop the Syncthing service (\`systemctl --user stop syncthing\`) and watch \`journalctl -t gnome-shell -f\` — there should be no repeating \`#pollState\` \`Unhandled promise rejection\` entries and no \`soup_message_queue_item_destroy\` runtime checks.
- [ ] Restart the service and confirm the indicator reconnects without leaking poll cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)