### PR TITLE
fix setName call sites left over from getter/setter refactor (#65)

### DIFF
--- a/src/syncthing.js
+++ b/src/syncthing.js
@@ -625,7 +625,7 @@ export class Manager extends Utils.Emitter {
         );
         this.folders.add(folder);
       } else {
-        this.folders.get(folderID).setName(name);
+        this.folders.get(folderID).name = name;
       }
       if (config.folders[i].paused) {
         this.folders.get(folderID).state = State.PAUSED;
@@ -708,7 +708,7 @@ export class Manager extends Utils.Emitter {
           }
         } else {
           device = this.devices.get(config.devices[i].deviceID);
-          device.setName(config.devices[i].name);
+          device.name = config.devices[i].name;
         }
       }
     }


### PR DESCRIPTION
## Summary

Closes #65.

`Item` was refactored in v50 to expose a `set name(name)` setter (instead of a `setName()` method), but two call sites in `#processConfig` still invoked the non-existent method:

- `src/syncthing.js:628` — folder rename path
- `src/syncthing.js:711` — device rename path

Both run on every config poll, so each poll throws `TypeError: this.folders.get(...).setName is not a function`, which on master surfaces as an unhandled rejection loop and pegs `gnome-shell` at high CPU. Fix is two characters: use the setter directly.

```diff
-        this.folders.get(folderID).setName(name);
+        this.folders.get(folderID).name = name;
...
-          device.setName(config.devices[i].name);
+          device.name = config.devices[i].name;
```

Credit to @andreanicoletto for the diagnosis in #65.

## Test plan

- [ ] Install the patched extension and reload the GNOME shell session.
- [ ] Rename a folder or device in the Syncthing Web UI.
- [ ] Watch `journalctl -t gnome-shell -f` — there should be no `TypeError: ... .setName is not a function` entries on the next config poll cycle.
- [ ] Confirm `gnome-shell` CPU stays normal (no busy loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)