### PR TITLE
destructure stdout from communicate_utf8_async + silence stderr

### DIFF
--- a/src/syncthing.js
+++ b/src/syncthing.js
@@ -896,10 +896,12 @@ export class Manager extends Utils.Emitter {
     for (let i = 1; i <= SYSTEMD_RETRIES; i++) {
       console.debug(LOG_PREFIX, "calling systemd", user, args.toString());
       try {
-        let proc = Gio.Subprocess.new(args, Gio.SubprocessFlags.STDOUT_PIPE);
-        result = (await proc.communicate_utf8_async(null, null))
-          .toString()
-          .replace(/[^a-z].?/, "");
+        let proc = Gio.Subprocess.new(
+          args,
+          Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_SILENCE,
+        );
+        const [stdout] = await proc.communicate_utf8_async(null, null);
+        result = (stdout || "").trim();
         break;
       } catch (error) {
         result = "error";


### PR DESCRIPTION
## Summary

Pre-existing latent bug in \`#serviceCommand\` (\`src/syncthing.js\`).

GJS' promisified \`communicate_utf8_async\` resolves to \`[stdout, stderr]\`. The current code calls \`.toString()\` on that array, which joins the elements with a comma (\`"active\\n,"\`), then strips the suffix with \`.replace(/[^a-z].?/, "")\` to recover \`"active"\`. That happened to work for the systemd statuses the code cares about, but it's brittle: any output with characters before the first non-lowercase position would be mangled.

Destructure \`[stdout]\` directly and \`.trim()\` it. Also pipe stderr to \`STDERR_SILENCE\` so transient \`systemctl\` errors no longer leak into \`journalctl\`.

```diff
-        let proc = Gio.Subprocess.new(args, Gio.SubprocessFlags.STDOUT_PIPE);
-        result = (await proc.communicate_utf8_async(null, null))
-          .toString()
-          .replace(/[^a-z].?/, "");
+        let proc = Gio.Subprocess.new(
+          args,
+          Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_SILENCE,
+        );
+        const [stdout] = await proc.communicate_utf8_async(null, null);
+        result = (stdout || "").trim();
```

Verified empirically with a small \`gjs\` script that the promisified call returns \`[stdout, stderr]\`.

No behavioural change for the supported systemd outputs (\`active\`, \`inactive\`, \`failed\`, \`enabled\`, \`disabled\`, \`error\`).

## Test plan

- [ ] Install the patched extension and reload the GNOME shell session.
- [ ] Confirm the systemd toggle still reflects service state correctly (start, stop, enable, disable).
- [ ] Confirm \`journalctl -t gnome-shell\` no longer carries stray systemctl stderr noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)