### PR TITLE
support syncthing 1.29 'serve --paths', fall back to legacy 'paths'

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -101,14 +101,13 @@ export default class Config {
   // Load configuration from Syncthing config file
   async loadFromConfigFile() {
     this.filePath = new ConfigFile();
-    try {
-      const proc = Gio.Subprocess.new(
-        [SYNCTHING_COMMAND, "paths"],
-        Gio.SubprocessFlags.STDOUT_PIPE,
-      );
-      const pathArray = (await proc.communicate_utf8_async(null, null))
-        .toString()
-        .split("\n\n");
+    // Syncthing >=1.29 dropped the top-level "paths" command; use "serve --paths".
+    // Older versions still need bare "paths".
+    const stdout =
+      (await this.#runSyncthing(["serve", "--paths"])) ||
+      (await this.#runSyncthing(["paths"]));
+    if (stdout) {
+      const pathArray = stdout.split("\n\n");
       const cmdPaths = {};
       for (let i = 0; i < pathArray.length; i++) {
         const items = pathArray[i].split(":\n\t");
@@ -117,12 +116,6 @@ export default class Config {
       if (this.CONFIG_PATH_KEY in cmdPaths) {
         this.filePath.addPath(cmdPaths[this.CONFIG_PATH_KEY][0]);
       }
-    } catch (error) {
-      console.warn(
-        LOG_PREFIX,
-        "executing syncthing binary failed",
-        error.message,
-      );
     }
 
     this.filePath.addPath(GLib.get_user_config_dir() + "/syncthing/config.xml");
@@ -157,6 +150,35 @@ export default class Config {
           this.filePath.path,
         );
       }
+    }
+  }
+
+  // Run syncthing CLI silently, return stdout on success, null on failure
+  async #runSyncthing(args) {
+    try {
+      const proc = Gio.Subprocess.new(
+        [SYNCTHING_COMMAND, ...args],
+        Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_SILENCE,
+      );
+      const [stdout] = await proc.communicate_utf8_async(null, null);
+      if (!proc.get_successful()) {
+        console.debug(
+          LOG_PREFIX,
+          "syncthing binary returned non-zero",
+          args.join(" "),
+          proc.get_exit_status(),
+        );
+        return null;
+      }
+      return stdout;
+    } catch (error) {
+      console.warn(
+        LOG_PREFIX,
+        "executing syncthing binary failed",
+        args.join(" "),
+        error.message,
+      );
+      return null;
     }
   }
 


### PR DESCRIPTION
## Summary

Syncthing 1.29 dropped the top-level \`paths\` command. On any system with Syncthing ≥1.29, every config-discovery probe now prints

```
syncthing: error: unexpected argument paths
```

to stderr, which the extension wasn't capturing — so it leaked into \`journalctl\` once per session start (and on every retry while the daemon was being detected). The actual path lookup failed silently and the extension fell back to the hardcoded \`~/.config/syncthing/config.xml\` and \`~/.local/state/syncthing/config.xml\` candidates, which works for default installs but not for users running Syncthing with a custom \`STCONFDIR\` / \`--home\`.

\`syncthing serve --paths\` produces the same output as the old \`paths\` command, so:

- Try \`serve --paths\` first.
- Fall back to legacy \`paths\` for older Syncthing versions.
- Pipe stderr to \`STDERR_SILENCE\` either way so the \"unexpected argument\" line doesn't leak into \`journalctl\`.
- Destructure \`[stdout]\` from the promisified \`communicate_utf8_async\` (it resolves to \`[stdout, stderr]\`, not a string — verified with a small \`gjs\` repro).
- Log non-zero exits at debug level so retries are observable without spamming the log.

Verified \`syncthing serve --paths\` doesn't actually start the daemon; it just dumps paths and exits 0.

## Test plan

- [ ] On Syncthing ≥1.29: install the patched extension, reload, and confirm the \`syncthing: error: unexpected argument paths\` line no longer appears in \`journalctl -t gnome-shell\`.
- [ ] On Syncthing <1.29 (if available): confirm the legacy \`paths\` fallback still resolves the config path.
- [ ] With a custom \`STCONFDIR\`: confirm the extension finds the right \`config.xml\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)