### PR TITLE
drop unused #extensionPath field from Config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -57,16 +57,14 @@ class ConfigFile {
 // Synthing configuration
 export default class Config {
   #parseAll;
-  #extensionPath;
   #autoConfig = true;
   #exists = false;
 
   CONFIG_PATH_KEY = "Configuration file";
 
-  constructor(settings, parseAll, extensionPath = null) {
+  constructor(settings, parseAll) {
     this.settings = settings;
     this.#parseAll = parseAll;
-    this.#extensionPath = extensionPath;
     this.clear();
   }
 


### PR DESCRIPTION
## Summary

`Config` stored an `extensionPath` constructor argument in a private field
(`#extensionPath`) but never read it anywhere in the class.

- Remove the `#extensionPath` private field declaration
- Remove the `extensionPath` parameter from the constructor (the single
  caller in `extension.js` already passed only two arguments)

## Test plan

- [ ] Build and reload the extension — no behaviour change expected
- [ ] Run `grep -r extensionPath src/` should return no results