### PR TITLE
reset #httpErrorCount on a successful response

### DIFF
--- a/src/syncthing.js
+++ b/src/syncthing.js
@@ -958,6 +958,10 @@ export class Manager extends Utils.Emitter {
           let errorReported = false;
           if (msg.status_code == Soup.Status.OK) {
             connected = true;
+            // Reset the strike counter so a single transient failure
+            // followed by a success doesn't accumulate toward an
+            // eventual ERROR emit.
+            this.#httpErrorCount = 0;
             let response;
             try {
               response = new TextDecoder("utf-8").decode(


### PR DESCRIPTION
## Summary

`#httpErrorCount` was only zeroed when it crossed `HTTP_ERROR_RETRIES`.
Two transient failures separated by any number of successes still accumulated,
so a flaky network eventually faked a permanent `ERROR` state even though the
connection had long recovered.

Reset the counter to `0` on every OK response so it tracks **consecutive**
failures only.

## Reproduction

1. Set `HTTP_ERROR_RETRIES = 3` (unchanged default)
2. Cause 2 transient HTTP errors (counter = 2)
3. Wait for a successful response — counter stays at 2
4. Cause 1 more transient error — counter = 3, triggers permanent ERROR state
   despite only one current failure

## Test plan

- [ ] Simulate flaky network; confirm the indicator recovers without entering
  a permanent ERROR state after isolated transient failures
- [ ] Confirm consecutive failures still trigger ERROR after `HTTP_ERROR_RETRIES`
  failed responses in a row