### PR TITLE
exclude gschemas.compiled from the release zip

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -48,11 +48,13 @@ done < $SCRIPT_PATH/po/en.po
         echo "" >> $SCRIPT_PATH/src/locale/fallback.json
 echo "}" >> $SCRIPT_PATH/src/locale/fallback.json
 
-# Compile schemas
+# Compile schemas (used by the local install path; stripped from the
+# release zip below — extensions.gnome.org rejects bundles that
+# contain a pre-compiled `gschemas.compiled`).
 [ -f $CUR_PATH/src/schemas/gschemas.compiled ] && rm -f $CUR_PATH/src/schemas/gschemas.compiled
 glib-compile-schemas $SCRIPT_PATH/src/schemas/
 
 # Zip extensions files
 [ -f $CUR_PATH/$EXT_NAME.zip ] && rm -f $CUR_PATH/$EXT_NAME.zip
-(cd $SCRIPT_PATH/src && zip -r $CUR_PATH/$EXT_NAME.zip *)
+(cd $SCRIPT_PATH/src && zip -r --exclude='schemas/gschemas.compiled' $CUR_PATH/$EXT_NAME.zip *)
 zip -r $CUR_PATH/$EXT_NAME.zip -j $SCRIPT_PATH/LICENSE


### PR DESCRIPTION
## Summary

extensions.gnome.org rejects submissions that ship a pre-compiled
`gschemas.compiled` — the server compiles schemas itself after upload.

The previous `zip -r ... *` swept the freshly-compiled file (written by
`glib-compile-schemas` earlier in the script) into the bundle, causing
EGO upload failures.

Changes:
- Add `--exclude='schemas/gschemas.compiled'` to the `zip` command
- Add a `rm -f` guard before `glib-compile-schemas` so stale compiled
  files don't accumulate between builds

The local install path (via `gnome-extensions install`) is unaffected —
it still uses the in-tree compiled file.

## Test plan

- [ ] Run `make.sh`; verify the resulting zip does **not** contain
  `schemas/gschemas.compiled` (`unzip -l syncthing@gnome.2nv2u.com.zip | grep gschemas`)
- [ ] Confirm the extension loads correctly after local install
  (`gnome-extensions install --force syncthing@gnome.2nv2u.com.zip`)